### PR TITLE
Pin the version of github-push-action used for docs, try to not force push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -158,10 +158,9 @@ jobs:
 
     - name: Push Changes to psi4/psi4docs
       if: github.repository == 'psi4/psi4'
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v1.0.0
       with:
         directory: ./docs
         repository: psi4/psi4docs
         github_token: ${{ secrets.psi4docs_from_psi4 }}
-        force: true
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Using ad-m/github-push-action@master in the action that pushes the updated docs is technically a software supply chain risk.
It handles sensitive data like a GH token, and could probably do bad things if the account of one of its maintainers was to be compromised. While the risk is remote, given how rarely it is normally updated, pinning its version would be good practice.

I don't see why the action was set to force push, but perhaps it would be worth seeing if we can do away with that.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Pin ad-m/github-push-action to the recent 1.0 release
- [x] Don't ask for a force push when pushing updated docs to psi4/psi4docs

## Checklist
- [x] No new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
